### PR TITLE
feat: Ability to define taints for nodepool, instance and instance pool mode

### DIFF
--- a/examples/workers/vars-workers-instance.auto.tfvars
+++ b/examples/workers/vars-workers-instance.auto.tfvars
@@ -20,4 +20,21 @@ worker_pools = {
     size        = 1,
     burst       = "BASELINE_1_8", # Valid values BASELINE_1_8,BASELINE_1_2
   },
+  oke-vm-instance-taint = {
+    description = "Self-managed Instance With taint",
+    mode        = "instance",
+    size        = 1,
+    taints = [
+      "project=workload-taint:NoSchedule"
+    ]
+  },
+  oke-vm-instance-multi-taint = {
+    description = "Self-managed Instance With multiple taint",
+    mode        = "instance",
+    size        = 1,
+    taints = [
+      "project=workload:NoSchedule",
+      "oke.oraclecloud.com/pool.name=oke-vm-instance-multi-taint:NoSchedule"
+    ]
+  },
 }

--- a/examples/workers/vars-workers-instancepool.auto.tfvars
+++ b/examples/workers/vars-workers-instancepool.auto.tfvars
@@ -33,4 +33,17 @@ worker_pools = {
     size                 = 1,
     disable_block_volume = true,
   },
+  oke-vm-instance-pool-taint = {
+    description = "Self-managed Instance Pool with taint",
+    mode        = "instance-pool",
+    size        = 1,
+    node_labels = {
+      "keya" = "valuea",
+      "keyb" = "valueb"
+    },
+    taints = [
+      "keya=valuea:NoSchedule",
+      "keyb=valueb:NoSchedule"
+    ]
+  },
 }

--- a/examples/workers/vars-workers-nodepool.auto.tfvars
+++ b/examples/workers/vars-workers-nodepool.auto.tfvars
@@ -38,4 +38,25 @@ worker_pools = {
     size        = 1,
     create      = false,
   },
+  oke-vm-standard-ol7-taint = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image with taints",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "7",
+    create      = true,
+    taints = [
+      "project=workload-taint:NoSchedule"
+    ]
+  },
+  oke-vm-standard-ol8-multiple-taints = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image with multiple taints",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "8",
+    create      = true,
+    taints = [
+      "project=workload-multi-taint:NoSchedule",
+      "oke.oraclecloud.com/pool.name=oke-vm-standard-ol8-multiple-taints:NoSchedule"
+    ]
+  },
 }

--- a/modules/workers/cloudinit-oke.sh
+++ b/modules/workers/cloudinit-oke.sh
@@ -77,7 +77,7 @@ function run_oke_init() { # Initialize OKE worker node
     fi
 
     if [[ -f "/etc/oke/kubelet-args" ]]; then
-      kubelet_extra_args="--kubelet-extra-args \"$(< /etc/oke/kubelet-args)\""
+      kubelet_extra_args="--kubelet-extra-args $(< /etc/oke/kubelet-args)"
     fi
 
     bash /etc/oke/oke-install.sh \

--- a/modules/workers/cloudinit-oke.sh
+++ b/modules/workers/cloudinit-oke.sh
@@ -62,7 +62,7 @@ function run_oke_init() { # Initialize OKE worker node
   fi
 
   if [[ -f /etc/oke/oke-install.sh ]]; then
-    local apiserver_host cluster_ca
+    local apiserver_host cluster_ca kubelet_extra_args
 
     if [[ -f "/etc/oke/oke-apiserver" ]]; then
       apiserver_host=$(< /etc/oke/oke-apiserver)
@@ -76,9 +76,14 @@ function run_oke_init() { # Initialize OKE worker node
       cluster_ca=$(get_imds_metadata | jq -rcM '.cluster_ca_cert')
     fi
 
+    if [[ -f "/etc/oke/kubelet-args" ]]; then
+      kubelet_extra_args="--kubelet-extra-args \"$(< /etc/oke/kubelet-args)\""
+    fi
+
     bash /etc/oke/oke-install.sh \
       --apiserver-endpoint "${apiserver_host}" \
-      --kubelet-ca-cert "${cluster_ca}"
+      --kubelet-ca-cert "${cluster_ca}" \
+      "${kubelet_extra_args}"
     return
   fi
    
@@ -91,7 +96,7 @@ function run_oke_init() { # Initialize OKE worker node
     for url in "http://169.254.169.254/" "http://[fd00:c1::a9fe:a9fe]/"; do
       echo "Attempting to fetch OKE init script from ${base_url}${oke_init_relative_path}"
       if curl -sSf -H 'Authorization: Bearer Oracle' -L0 "${url}${oke_init_relative_path}" | base64 --decode > "${script_path}"; then
-        bash "${script_path}"
+        bash "${script_path} ${kubelet_extra_args}"
         exit 0
       fi
     done

--- a/modules/workers/cloudinit-oke.sh
+++ b/modules/workers/cloudinit-oke.sh
@@ -83,7 +83,7 @@ function run_oke_init() { # Initialize OKE worker node
     bash /etc/oke/oke-install.sh \
       --apiserver-endpoint "${apiserver_host}" \
       --kubelet-ca-cert "${cluster_ca}" \
-      "${kubelet_extra_args}"
+      ${kubelet_extra_args}
     return
   fi
    

--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -89,13 +89,27 @@ data "cloudinit_config" "workers" {
             encoding = "base64"
             path     = "/etc/kubernetes/ca.crt"
           },
+        ]
+      })
+      filename   = "50-oke-config.yml"
+      merge_type = local.default_cloud_init_merge_type
+    }
+  }
+
+  # Write kubelet extra arg to filesystem
+  dynamic "part" {
+    for_each = !each.value.disable_default_cloud_init && length(each.value.taints) > 0 ? [1] : []
+    content {
+      content_type = "text/cloud-config"
+      content = jsonencode({
+        write_files = [
           {
             content  = "--register-with-taints=${join(",", each.value.taints)}"
             path     = "/etc/oke/kubelet-args"
           },
         ]
       })
-      filename   = "50-oke-config.yml"
+      filename   = "50-kubelet-arg-config.yml"
       merge_type = local.default_cloud_init_merge_type
     }
   }

--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -91,7 +91,6 @@ data "cloudinit_config" "workers" {
           },
           {
             content  = "--register-with-taints=${join(",", each.value.taints)}"
-            encoding = "base64"
             path     = "/etc/oke/kubelet-args"
           },
         ]

--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -90,7 +90,7 @@ data "cloudinit_config" "workers" {
             path     = "/etc/kubernetes/ca.crt"
           },
           {
-            content  = "--register-with-taints=${join(",", each.value.taint)}"
+            content  = "--register-with-taints=${join(",", each.value.taints)}"
             encoding = "base64"
             path     = "/etc/oke/kubelet-args"
           },

--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -89,6 +89,11 @@ data "cloudinit_config" "workers" {
             encoding = "base64"
             path     = "/etc/kubernetes/ca.crt"
           },
+          {
+            content  = "--register-with-taints=${join(",", each.value.taint)}"
+            encoding = "base64"
+            path     = "/etc/oke/kubelet-args"
+          },
         ]
       })
       filename   = "50-oke-config.yml"


### PR DESCRIPTION
Added the ability to define taints for worker node in mode , node-pool, instance and instance-pool
Fixes issue: https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/1010

When worker nodes are added as nodepool, instance pool or instance , we need an ability to define taints

Define the worker_pools variable for oke like below as example

```
module "k8s_infra" {
  source                             = "oracle-terraform-modules/oke/oci"
  version                            = "xxxx"
....
worker_pools                       = local.worker_pools
....
}
locals {
    oke-vm-instance-pool= {
      mode             = "instance-pool",
      size             = 1,
      shape            = "VM.Standard.E4.Flex",
      create           = true,
      ocpus            = 1,
      memory           = 16,

    },
    oke-vm-instance    = {
      mode             = "instance",
      size             = 1,
      shape            = "VM.Standard.E4.Flex",
      create           = true,
      ocpus            = 1,
      memory           = 16,
    },
    oke-vm-node-pool   = {
      mode             = "node-pool",
      size             = 1,
      os               = "Oracle Linux",
      os_version       = "7",
      create           = true,
      taints = [
        "project=workload-taint:NoSchedule"
      ]
    },
  }
```
